### PR TITLE
fix linspace error

### DIFF
--- a/cosmoTransitions/pathDeformation.py
+++ b/cosmoTransitions/pathDeformation.py
@@ -758,7 +758,7 @@ class SplinePath:
             xmin = optimize.fmin(V_lin, 0.0, args=(pts[0], dpts[0], V),
                                  xtol=1e-6, disp=0)[0]
             if xmin > 0.0: xmin = 0.0
-            nx = np.ceil(abs(xmin)-.5) + 1
+            nx = int(np.ceil(abs(xmin)-.5)) + 1
             x = np.linspace(xmin, 0, nx)[:, np.newaxis]
             pt_ext = pts[0] + x*dpts[0]
             pts = np.append(pt_ext, pts[1:], axis=0)
@@ -766,7 +766,7 @@ class SplinePath:
             xmin = optimize.fmin(V_lin, 0.0, args=(pts[-1], dpts[-1], V),
                                  xtol=1e-6, disp=0)[0]
             if xmin < 0.0: xmin = 0.0
-            nx = np.ceil(abs(xmin)-.5) + 1
+            nx = int(np.ceil(abs(xmin)-.5)) + 1
             x = np.linspace(xmin, 0, nx)[::-1, np.newaxis]
             pt_ext = pts[-1] + x*dpts[-1]
             pts = np.append(pts[:-1], pt_ext, axis=0)

--- a/cosmoTransitions/tunneling1D.py
+++ b/cosmoTransitions/tunneling1D.py
@@ -730,7 +730,7 @@ class SingleFieldInstanton:
         if max_interior_pts > 0:
             dx0 = R[1]-R[0]
             if R[0] / dx0 <= max_interior_pts:
-                n = np.ceil(R[0]/dx0)
+                n = int(np.ceil(R[0]/dx0))
                 R_int = np.linspace(0, R[0], n+1)[:-1]
             else:
                 n = max_interior_pts


### PR DESCRIPTION
Hi Carroll,

numpy was throwing errors about float valued arguments for the number of points in np.linspace() for me (python 3.9.2, numpy 1.20.1), so I added explicit casts to int around the np.ceil calls. I'm not sure in which numpy version it broke, or if np.ceil or np.linspace is to blame, but it's a trivial fix either way.

Thanks a lot for still looking out for this code after all these years.

Fixes #24, which reports the same error I was getting.

Cheers,
Jonas