### PR TITLE
Fix SciPy deprecation warnings

### DIFF
--- a/cosmoTransitions/pathDeformation.py
+++ b/cosmoTransitions/pathDeformation.py
@@ -34,8 +34,15 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from scipy import optimize, interpolate, integrate
+from scipy import optimize, interpolate
 from collections import namedtuple
+
+try:
+    from scipy.integrate import cumulative_trapezoid, odeint
+except ImportError:
+    # scipy.version < 1.6
+    from scipy.integrate import cumtrapz as cumulative_trapezoid
+    from scipy.integrate import odeint
 
 from . import tunneling1D
 from . import helper_functions
@@ -773,7 +780,7 @@ class SplinePath:
             # Recalculate the derivative
             dpts = _pathDeriv(pts)
         # 3. Find knot positions and fit the spline.
-        pdist = integrate.cumulative_trapezoid(np.sqrt(np.sum(dpts*dpts, axis=1)),
+        pdist = cumulative_trapezoid(np.sqrt(np.sum(dpts*dpts, axis=1)),
                                                initial=0.0)
         self.L = pdist[-1]
         k = min(len(pts)-1, 3)  # degree of the spline
@@ -783,7 +790,7 @@ class SplinePath:
             def dpdx(_, x):
                 dp = np.array(interpolate.splev(x, self._path_tck, der=1))
                 return np.sqrt(np.sum(dp*dp))
-            pdist = integrate.odeint(dpdx, 0., pdist,
+            pdist = odeint(dpdx, 0., pdist,
                                      rtol=0, atol=pdist[-1]*1e-8)[:,0]
             self.L = pdist[-1]
             self._path_tck = interpolate.splprep(pts.T, u=pdist, s=0, k=k)[0]

--- a/cosmoTransitions/pathDeformation.py
+++ b/cosmoTransitions/pathDeformation.py
@@ -773,8 +773,8 @@ class SplinePath:
             # Recalculate the derivative
             dpts = _pathDeriv(pts)
         # 3. Find knot positions and fit the spline.
-        pdist = integrate.cumtrapz(np.sqrt(np.sum(dpts*dpts, axis=1)),
-                                   initial=0.0)
+        pdist = integrate.cumulative_trapezoid(np.sqrt(np.sum(dpts*dpts, axis=1)),
+                                               initial=0.0)
         self.L = pdist[-1]
         k = min(len(pts)-1, 3)  # degree of the spline
         self._path_tck = interpolate.splprep(pts.T, u=pdist, s=0, k=k)[0]

--- a/cosmoTransitions/tunneling1D.py
+++ b/cosmoTransitions/tunneling1D.py
@@ -18,8 +18,14 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from scipy import optimize, integrate, special, interpolate
+from scipy import optimize, special, interpolate
 from collections import namedtuple
+
+try:
+    from scipy.integrate import simpson
+except ImportError:
+    # scipy.version < 1.6
+    from scipy.integrate import simps as simpson
 
 from . import helper_functions
 from .helper_functions import rkqs, IntegrationError, clampVal
@@ -778,7 +784,7 @@ class SingleFieldInstanton:
         # And integrate the profile
         integrand = 0.5 * dphi**2 + self.V(phi) - self.V(self.phi_metaMin)
         integrand *= area
-        S = integrate.simpson(integrand, x=r)
+        S = simpson(integrand, x=r)
         # Find the bulk term in the bubble interior
         volume = r[0]**d * np.pi**(d*.5)/special.gamma(d*.5 + 1)
         S += volume * (self.V(phi[0]) - self.V(self.phi_metaMin))

--- a/cosmoTransitions/tunneling1D.py
+++ b/cosmoTransitions/tunneling1D.py
@@ -778,7 +778,7 @@ class SingleFieldInstanton:
         # And integrate the profile
         integrand = 0.5 * dphi**2 + self.V(phi) - self.V(self.phi_metaMin)
         integrand *= area
-        S = integrate.simps(integrand, r)
+        S = integrate.simpson(integrand, x=r)
         # Find the bulk term in the bubble interior
         volume = r[0]**d * np.pi**(d*.5)/special.gamma(d*.5 + 1)
         S += volume * (self.V(phi[0]) - self.V(self.phi_metaMin))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="cosmoTransitions",
-    version="2.1.0",
+    version="2.0.7",
     packages=['cosmoTransitions', 'cosmoTransitions.examples'],
     package_dir={'cosmoTransitions.examples': 'examples'},
     description=(
@@ -12,12 +12,14 @@ setup(
     author="Carroll L. Wainwright",
     author_email="clwainwri@gmail.com",
     url="https://github.com/clwainwright/CosmoTransitions",
-    python_requires='>3.7',
-    install_requires=['numpy>=1.16.5', 'scipy>=1.6'],
+    install_requires=['numpy>=1.8', 'scipy>=0.11'],
     license="MIT",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="cosmoTransitions",
-    version="2.0.6",
+    version="2.1.0",
     packages=['cosmoTransitions', 'cosmoTransitions.examples'],
     package_dir={'cosmoTransitions.examples': 'examples'},
     description=(

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,12 @@ setup(
     author="Carroll L. Wainwright",
     author_email="clwainwri@gmail.com",
     url="https://github.com/clwainwright/CosmoTransitions",
-    install_requires=['numpy>=1.8', 'scipy>=0.11'],
+    python_requires='>3.7',
+    install_requires=['numpy>=1.16.5', 'scipy>=1.6'],
     license="MIT",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
     ],
 )


### PR DESCRIPTION
In [SciPy v1.6](https://docs.scipy.org/doc/scipy-1.6.0/reference/release.1.6.0.html?highlight=cumtrapz) the names of two functions used in CosmoTransitions were renamed: `scipy.integrate.simps` was renamed `scipy.integrate.simpson` and `scipy.integrate.cumtrapz` was renamed `scipy.integrate.cumulative_trapezoid`. Until now, the old names of these two functions have been kept around for backwards compatability.

In SciPy v1.14 the old names will be removed; see [here](https://github.com/scipy/scipy/blob/v1.13.0/scipy/integrate/_quadrature.py#L432-L536) and [here](https://github.com/scipy/scipy/blob/v1.13.0/scipy/integrate/_quadrature.py#L591-L837). Also in SciPy v1.14, the simpson function must have the keyword argument `x=...` passed with the keyword explicit. In v1.12 there is a deprecation warning for this.

To avoid CosmoTransitions breaking when SciPy v1.14 comes around, in this PR two lines of source code have been changed. Note however, this PR would break CosmoTransitions for SciPy versions older than 1.6.0 (and hence NumPy versions older than 1.16.5 and Python versions older than 3.7, see [here](https://docs.scipy.org/doc/scipy/dev/toolchain.html)). So, the version requirements in the setup.py file have been changed in this PR to reflect this. As a consequence, this PR also bumps the minor version number.